### PR TITLE
Removed .unit because it can be inferred by the presence of the size class

### DIFF
--- a/core/grid/grids.css
+++ b/core/grid/grids.css
@@ -1,6 +1,6 @@
 .line:after,.lastUnit:after{clear:both;display:block;visibility:hidden;overflow:hidden;height:0 !important;line-height:0;font-size:xx-large;content:" x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x ";}
 .line{*zoom:1;}
-.unit{float:left;}
+.size1of1,.size1of2,.size1of3,.size2of3,.size1of4,.size3of4,.size1of5,.size2of5,.size3of5,.size4of5{float:left;}
 .size1of1{float:none;}
 .size1of2{width:50%;}
 .size1of3{width:33.33333%;}

--- a/core/grid/grids.css
+++ b/core/grid/grids.css
@@ -1,6 +1,6 @@
 .line:after,.lastUnit:after{clear:both;display:block;visibility:hidden;overflow:hidden;height:0 !important;line-height:0;font-size:xx-large;content:" x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x ";}
 .line{*zoom:1;}
-.size1of1,.size1of2,.size1of3,.size2of3,.size1of4,.size3of4,.size1of5,.size2of5,.size3of5,.size4of5{float:left;}
+.size1of2,.size1of3,.size2of3,.size1of4,.size3of4,.size1of5,.size2of5,.size3of5,.size4of5{float:left;}
 .size1of1{float:none;}
 .size1of2{width:50%;}
 .size1of3{width:33.33333%;}


### PR DESCRIPTION
The .unit class is redundant and does nothing without an additonal size class anyway,
so why not just use the size class. I realize its kind of a long rule, but the benefits 
are that it
- doesn't affect the cascade
- is backward compatible with existing markup
- saves a considerable amount of markup
- reduces user error (one less thing to remember when marking up grids)

P.S. This is my first attempt at collaborating on github and I have no idea if I'm doing it right.
