### PR TITLE
Added support for grids divided by 7

### DIFF
--- a/core/grid/grids.css
+++ b/core/grid/grids.css
@@ -11,4 +11,10 @@
 .size2of5{width:40%;}
 .size3of5{width:60%;}
 .size4of5{width:80%;}
+.size1of7{width:14.2857143%;}
+.size2of7{width:28.5714286%;}
+.size3of7{width:42.8571429%;}
+.size4of7{width:57.1428572%;}
+.size5of7{width:71.4285715%;}
+.size6of7{width:85.7142858%;}
 .lastUnit{display:table-cell;float:none;width:auto;*display:block;*zoom:1;_position:relative;_left:-3px;_margin-right:-3px;}

--- a/core/grid/grids.css
+++ b/core/grid/grids.css
@@ -11,10 +11,4 @@
 .size2of5{width:40%;}
 .size3of5{width:60%;}
 .size4of5{width:80%;}
-.size1of7{width:14.2857143%;}
-.size2of7{width:28.5714286%;}
-.size3of7{width:42.8571429%;}
-.size4of7{width:57.1428572%;}
-.size5of7{width:71.4285715%;}
-.size6of7{width:85.7142858%;}
 .lastUnit{display:table-cell;float:none;width:auto;*display:block;*zoom:1;_position:relative;_left:-3px;_margin-right:-3px;}

--- a/plugins/grids7/grids7.css
+++ b/plugins/grids7/grids7.css
@@ -1,0 +1,7 @@
+/* Allow grid divisions of 1/7 etc. */
+.size1of7{width:14.2857143%;}
+.size2of7{width:28.5714286%;}
+.size3of7{width:42.8571429%;}
+.size4of7{width:57.1428572%;}
+.size5of7{width:71.4285715%;}
+.size6of7{width:85.7142858%;}


### PR DESCRIPTION
7 column grids, while admittedly not particularly common in general layout situations, can be pretty handy. A good example would be calendar layouts showing seven days to view. Given that seven is a prime number, it cannot be created with any combination of the existing grid classes, hence the need for this addition.
