### PR TITLE
Added plugin for grids divided by 6

### DIFF
--- a/plugins/grids6/grids6.css
+++ b/plugins/grids6/grids6.css
@@ -1,0 +1,3 @@
+/* Allow grid divisions of 1/6 etc. */
+.size1of6{width:16.6666666%;}
+.size5of6{width:83.3333333%;}


### PR DESCRIPTION
Existing fractions are left out, similar to the current core grids CSS. No `.size2of4` exists since it equals `.size1of2`. Same goes for `.size3of6`, etc.
