### PR TITLE
Put back position:relative on mod/pop.

### DIFF
--- a/core/module/mod.css
+++ b/core/module/mod.css
@@ -27,7 +27,7 @@ b.top, b.top b, b.bottom, b.bottom b{display:block;background-repeat:no-repeat;f
 .complex .bottom{height:5px;/*margin-top:-10px;*/}
 /* pop */
 .pop{overflow:visible;margin: 10px 20px 20px 10px; background-position:left top;}
-.pop .inner{right:-10px; bottom:-10px; background-position:right bottom;padding:0 10px 10px 0;}
+.pop .inner{position:relative;right:-10px; bottom:-10px;background-position:right bottom;padding:0 10px 10px 0;}
 .pop .tl, .pop .br{display:none;}
 .pop .bl{bottom:-10px;}
 .pop .tr{float:right;margin-right:-10px;_display:inline; /*fix double margin bug*/ }

--- a/core/module/mod_doc.html
+++ b/core/module/mod_doc.html
@@ -74,7 +74,8 @@
 							<li>Choose when you require outside transparency which cannot be simulated. (do i need to make this work with clip rather than bkg position?)</li>
 						</ul>
 						<p>Inspired by <a href="http://www.lesliesommer.com/wdw07/html/" title="CSS Mojo: Adding Polish To Your Pages">Leslie Sommer’s Mojo blocks</a>.</p>
-					</div>
+            <p><strong>Warning:</strong> This module uses position:relative on its inner div.</p>
+          </div>
 				</div>
 				<b class="bottom"><b class="bl"></b><b class="br"></b></b>
 			</div>


### PR DESCRIPTION
Hi there,

mod/pop is broken in the current master - see the examples in mod_doc.html . This seems to be a direct consequence of the previous "newFormattingContext" merge, in which the .mod .inner element lost its "display: inline" property.

I've been studying this for 2 evenings and I think that the strategy used in mod/pop can't be used without having an relatively-positioned inner div; it just relies too much on that. In my opinion, there are only two courses of action:
- Applying position:relative only to .pop .inner , not the other mods.
- Re-thinking pop completely

On this pull request I'm making it relatively positioned. I humbly suggest that this gets merged into master, at least while a better solution is found.
