### PR TITLE
Grids: Preventing column collapse when a unit is empty

### DIFF
--- a/core/grid/grids.css
+++ b/core/grid/grids.css
@@ -1,5 +1,5 @@
 .line,.lastUnit{overflow:hidden; *overflow:visible;*zoom:1;}
-.unit{float:left;}
+.unit{float:left; min-height: 1px;}
 .unitRight{float:right;}
 .size1of1{float:none;}
 .size1of2{width:50%;}


### PR DESCRIPTION
When a unit is empty, the column collapses. The min-height on units prev...ents this from happening. Works in all browsers except IE6 and below, which simply ignore the property.
