### PR TITLE
Clearfix tabs

### DIFF
--- a/core/module/mod.css
+++ b/core/module/mod.css
@@ -26,8 +26,9 @@ b.top, b.top b, b.bottom, b.bottom b{display:block;background-repeat:no-repeat;f
 .complex .top{height:5px;}
 .complex .bottom{height:5px;/*margin-top:-10px;*/}
 /* pop */
-.pop{overflow:visible;margin: 10px 20px 20px 10px; background-position:left top;}
-.pop .inner{right:-10px; bottom:-10px; background-position:right bottom;padding:0 10px 10px 0;}
+.pop{overflow:visible;margin: 10px 20px 20px 10px; background-position:left top; padding-top:1px;/*padding to avoid margin collapsing*/}
+.pop .inner{right:-10px; bottom:-10px; margin:9px -10px -10px 10px; background-position:right bottom;padding:0 10px 10px 0;}
 .pop .tl, .pop .br{display:none;}
-.pop .bl{bottom:-10px;}
-.pop .tr{float:right;margin-right:-10px;_display:inline; /*fix double margin bug*/ }
+.pop .bottom{height:0;}
+.pop .bl{float:none;}
+.pop .tr{float:right;margin-right:-10px;margin-top:-1px;/*corresponding to padding*/_display:inline;/*fix double margin bug*/ }

--- a/plugins/tabs/tabs.css
+++ b/plugins/tabs/tabs.css
@@ -30,6 +30,32 @@ TODO: clean up selector structure - too much variation in rule strength
 .controls{position:absolute; top:0; right: 0; display: none !important; /* this should move to its' own plugin */}
 .controls a{padding: 10px;}
 
+/**
+ * For modern browsers
+ * 1. The space content is one way to avoid an Opera bug when the
+ *    contenteditable attribute is included anywhere else in the document.
+ *    Otherwise it causes space to appear at the top and bottom of elements
+ *    that are clearfixed.
+ * 2. The use of `table` rather than `block` is only necessary if using
+ *    `:before` to contain the top-margins of child elements.
+ */
+.cf:before,
+.cf:after {
+    content: " "; /* 1 */
+    display: table; /* 2 */
+}
+
+.cf:after {
+    clear: both;
+}
+
+/**
+ * For IE 6/7 only
+ * Include this rule to trigger hasLayout and contain floats.
+ */
+.cf {
+    *zoom: 1;
+}
 
 .tabPosLeft .hd .tabControl .current {background-image:none; border-bottom:solid 1px #e2e2e2;border-right:none; margin-right:-1px;}
 .tabPosLeft .tabControl li{border-right:none;}

--- a/plugins/tabs/tabs_doc.html
+++ b/plugins/tabs/tabs_doc.html
@@ -53,7 +53,7 @@
 <h2>Left-side tabs</h2>
 <div class="mod simple tabs tabPosLeft">
 	<b class="top"><b class="tl"></b><b class="tr"></b></b>
-	<div class="inner">
+	<div class="inner cf">
 		<div class="hd topper">
 			<ul class="tabControl"><li><a href="#"><span>Tab 1</span></a></li><li><a href="#"><span>Tab 2</span></a></li><li class="current"><a href="#"><span>Tab 3 <br /> boo foo foo</span></a></li><li><a href="#"><span>Tab 4</span></a></li><li><a href="#"><span>Tab 5</span></a></li><li><a href="#"><span>Tab 6 has lots and lots of text on one line</span></a></li></ul>
 			<ul class="controls"><li><a href="#"><span>x</span></a></li><li><a href="#"><span>-</span></a></li><li><a href="#"><span>+</span></a></li></ul>
@@ -76,7 +76,7 @@
 <h2>Right-side tabs</h2>
 <div class="mod simple tabs tabPosRight">
 	<b class="top"><b class="tl"></b><b class="tr"></b></b>
-	<div class="inner">
+	<div class="inner cf">
 		<div class="hd topper">
 			<ul class="tabControl"><li><a href="#"><span>Tab 1</span></a></li><li><a href="#"><span>Tab 2</span></a></li><li class="current"><a href="#"><span>Tab 3 <br /> boo foo foo</span></a></li><li><a href="#"><span>Tab 4</span></a></li><li><a href="#"><span>Tab 5</span></a></li><li><a href="#"><span>Tab 6 has lots and lots of text on one line</span></a></li></ul>
 			<ul class="controls"><li><a href="#"><span>x</span></a></li><li><a href="#"><span>-</span></a></li><li><a href="#"><span>+</span></a></li></ul>


### PR DESCRIPTION
The tabs plugin needs a clearfix, so that tabs on the left or right will not overflow. see http://nicolasgallagher.com/micro-clearfix-hack/
