### PR TITLE
Update _pxToEm.scss

### DIFF
--- a/oocss/src/components/utils/_pxToEm.scss
+++ b/oocss/src/components/utils/_pxToEm.scss
@@ -15,7 +15,7 @@
   $list: ();
 
   @each $value in $values {
-    @if ($value == 0) {
+    @if ($value == 0 or $value == auto) {
       $list: append($list, $value);
     } @else {
       $emValue: ($value/$elFontSize)+em;


### PR DESCRIPTION
Added a check for if the value 'auto' is passed to the function to deal with cases where auto is desired as an output.  for example:

margin: pxToEm(20px auto, 16px); would output -> margin: 1.25em auto;
