### PR TITLE
Fixed duplicate Field Group Label->Id & For attributes

### DIFF
--- a/oocss/documentation/handlebar-helpers-reference.md
+++ b/oocss/documentation/handlebar-helpers-reference.md
@@ -66,4 +66,29 @@ as a var in helpers
     <code>{{#if $myvar}}do stuff{{/if}}</code>
 
 ***
+####repeat (repeatCount, indexPrefix, options)
 
+|Param      |Type    |Description
+|-----------|--------|--------------
+|repeatCount|{Number}|The number of repeats
+|indexPrefix|{String}|prefix that will be used for the var @indexStr
+|options    |{Object}|[optional] Object passed through handlebars|
+
+return: none
+
+usage:
+
+     <ul>
+          {{#repeat 2 "myPrefix"}}
+               <li>{{@indexStr}}</li>
+          {{/repeat}}
+     </ul>
+     
+     would output
+     
+     <ul>
+          <li>myPrefix0</li>
+          <li>myPrefix1</li>
+     </ul>
+
+***

--- a/oocss/documentation/handlebar-helpers-reference.md
+++ b/oocss/documentation/handlebar-helpers-reference.md
@@ -10,14 +10,14 @@
 |rightValue|{Object}|Right value to compare|
 |options   |{Object}|[optional] Object passed through handlebars|
 
-return:
+>**Return**:
 
 Type    |Description
 |-------|-----------
 {bool}  |The result of the comparison
 
 
-usage:
+>**Usage:**
 
      {{#compare unicorns "<" ponies}}
        I knew it, unicorns are just low-quality ponies!
@@ -44,26 +44,30 @@ usage:
 |varName   |{String}|The name of the variable you want to create|
 |options   |{Object}|[optional] Object passed through handlebars|
 
-return:
+>**Return:**
 
 Type    |Description
 |-------|-----------
 {String}|formatted html
 
-usage:
+>**Usage:**
      
 Declare the var :
 
-    <code>{{#createvar "myvar"}}content of {{prop of object}}{{/createvar}}</code>
+     {{#createvar "myvar"}}content of {{prop of object}}{{/createvar}}
 
 Use the var :
 as a normal property inside the template
 
-    <code>{{$myvar}}</code>
+     <p>{{$myvar}}</p>
     
 as a var in helpers
 
-    <code>{{#if $myvar}}do stuff{{/if}}</code>
+     {{#if $myvar}}
+          
+          <p>do stuff here</p>
+          
+     {{/if}}
 
 ***
 ####repeat (repeatCount, indexPrefix, options)
@@ -74,9 +78,11 @@ as a var in helpers
 |indexPrefix|{String}|prefix that will be used for the var @indexStr
 |options    |{Object}|[optional] Object passed through handlebars|
 
-return: none
+>**Return:**
 
-usage:
+none
+
+>**Usage:**
 
      <ul>
           {{#repeat 2 "myPrefix"}}
@@ -90,5 +96,26 @@ usage:
           <li>myPrefix0</li>
           <li>myPrefix1</li>
      </ul>
+
+***
+####format (options)
+
+>Format HTML code by using html prettyPrint 
+
+|Param      |Type    |Description
+|-----------|--------|--------------
+|options    |{Object}|[optional] Object passed through handlebars
+
+>**Return:**
+
+Type    |Description
+|-------|-----------
+{String}|formatted html
+
+>**Usage:**
+     
+     {{#format}}
+          <ul><li>code</li></ul>
+     {{/format}}
 
 ***

--- a/oocss/documentation/handlebar-helpers-reference.md
+++ b/oocss/documentation/handlebar-helpers-reference.md
@@ -1,7 +1,7 @@
 #Registered Handlebar Helpers Reference
 
 
-####compare (leftValue, operator, rightValue, options)
+####compare (leftValue, operator, rightValue, [options])
 
 |Param     |Type    |Description
 |----------|--------|--------------
@@ -37,7 +37,7 @@ Type    |Description
 |text      |{String}|Text which you want to replace a new line (\n\r) to a &lt;br /&gt;
 
 ***
-####createvar (varName, options)
+####createvar (varName, [options])
 
 |Param     |Type    |Description
 |----------|--------|--------------
@@ -70,7 +70,7 @@ as a var in helpers
      {{/if}}
 
 ***
-####repeat (repeatCount, indexPrefix, options)
+####repeat (repeatCount, indexPrefix, [options])
 
 |Param      |Type    |Description
 |-----------|--------|--------------
@@ -98,7 +98,7 @@ none
      </ul>
 
 ***
-####format (options)
+####format ([options])
 
 >Format HTML code by using html prettyPrint 
 
@@ -119,7 +119,7 @@ Type    |Description
      {{/format}}
 
 ***
-####htmlcode (codeLang, options)
+####htmlcode ([codeLang], [options])
 
 >Adds &lt;pre&gt;&lt;code&gt; tags around code placed inside the {{code}} place holder
 
@@ -147,7 +147,7 @@ Type     |Description
      {{/htmlcode}}
      
 ***
-####debug (outputText)
+####debug ([outputText])
 >debug helper which writes the contents of the *this* object to the console.
 
 |Param       |Type    |Description
@@ -167,7 +167,7 @@ none
      {{debug "this is text printed in the console" }}
 
 ***
-####partial (name, options)
+####partial (name, [options])
 >Allows you to create re-usable String templates or compiled template functions.
 >[More info](https://github.com/wycats/handlebars.js/#partials)
 
@@ -188,3 +188,64 @@ none
 >**Usage:**
      
      {{> myPartialName}}
+
+***
+####registerBlock (blockname, [varParams[...]], [options])
+>Allows you to register your own handlebar place holders
+
+|Param    |Type    |Description
+|---------|--------|--------------
+|blockname|{String}|Name of the block you want to register
+|varParams|{Object}|[optional] User definable params. i.e. "var1", "var2", "var3" and so on
+|options  |{Object}|[optional] Object passed through handlebars
+
+>**Return:**
+
+none
+
+>**Declaration:**
+     
+     {{#registerBlock "myBlock" "var1" "var2" }}
+          <div class="{{$var1}}">
+               {{$var2}}
+          </div>
+          {{#if $content}}<div class="text">$content</div>{{/if}}
+     {{/registerBlock}}
+     
+>**Usage:**
+     
+     {{#myBlock "paragraph1" "my var2"}}
+          <div class="{{$var1}}">
+               {{$var2}}
+          </div>
+          content of the block that is sent to $content
+     {{/myBlock}}
+     
+     outputs:
+     
+     <div class="paragraph1">
+          my var2
+     </div>
+     <div class="text">content of the block that is sent to $content</div>
+     
+***
+####block (blockname, [varParams[...]], [options])
+>this method is useful for calling another block
+
+|Param    |Type    |Description
+|---------|--------|--------------
+|blockname|{String}|Name of the block you want to call
+|varParams|{Object}|[optional] params sent to the block your calling. i.e. "var1", "var2", "var3" and so on
+|options  |{Object}|[optional] Object passed through handlebars
+
+>**Return:**
+
+Returns the result from the block being called
+
+>**Usage:**
+
+     {{block myblockname "var1" "var2" "var3"}}....
+
+***
+
+

--- a/oocss/documentation/handlebar-helpers-reference.md
+++ b/oocss/documentation/handlebar-helpers-reference.md
@@ -1,0 +1,2 @@
+﻿#Registered Handlebar Helpers Reference
+

--- a/oocss/documentation/handlebar-helpers-reference.md
+++ b/oocss/documentation/handlebar-helpers-reference.md
@@ -1,14 +1,20 @@
-﻿#Registered Handlebar Helpers Reference
+#Registered Handlebar Helpers Reference
 
 
-##### compare (leftValue, operator, rightValue, options)
+####compare (leftValue, operator, rightValue, options)
 
-|Param     |Description
-|----------|-----------------------------------------------------------|
-|leftValue |Left value to compare                                      |
-|operator  |The operator, must be between quotes ">", "=", "<=", etc...|
-|rightValue|Right value to compare                                     |
-|options   |Option object sent by handlebars                           |
+|Param     |Type    |Description
+|----------|--------|--------------
+|leftValue |{Object}|Left value to compare|
+|operator  |{String}|The operator, must be between quotes ">", "=", "<=", etc...|
+|rightValue|{Object}|Right value to compare|
+|options   |{Object}|[optional] Object passed through handlebars|
+
+return:
+
+Type    |Description
+|-------|-----------
+{bool}  |The result of the comparison
 
 
 usage:
@@ -23,10 +29,41 @@ usage:
      The value is lower than 10
      {{/compare}}
 
-#####nl2br (text)
+***
+####nl2br (text)
 
-|Param     |Description
-|----------|------------|
-|text      |Text which you want to replace a new line (\n\r) to a &lt;br /&gt;
+|Param     |Type    |Description
+|----------|--------|--------------
+|text      |{String}|Text which you want to replace a new line (\n\r) to a &lt;br /&gt;
 
+***
+####createvar (varName, options)
+
+|Param     |Type    |Description
+|----------|--------|--------------
+|varName   |{String}|The name of the variable you want to create|
+|options   |{Object}|[optional] Object passed through handlebars|
+
+return:
+
+Type    |Description
+|-------|-----------
+{String}|formatted html
+
+usage:
+     
+Declare the var :
+
+    <code>{{#createvar "myvar"}}content of {{prop of object}}{{/createvar}}</code>
+
+Use the var :
+as a normal property inside the template
+
+    <code>{{$myvar}}</code>
+    
+as a var in helpers
+
+    <code>{{#if $myvar}}do stuff{{/if}}</code>
+
+***
 

--- a/oocss/documentation/handlebar-helpers-reference.md
+++ b/oocss/documentation/handlebar-helpers-reference.md
@@ -1,2 +1,25 @@
 ﻿#Registered Handlebar Helpers Reference
 
+
+##### compare (leftValue, operator, rightValue, options)
+
+|Param     |Description
+|----------|-----------------------------------------------------------|
+|leftValue |Left value to compare                                      |
+|operator  |The operator, must be between quotes ">", "=", "<=", etc...|
+|rightValue|Right value to compare                                     |
+|options   |Option object sent by handlebars                           |
+
+
+usage:
+
+     {{#compare unicorns "<" ponies}}
+       I knew it, unicorns are just low-quality ponies!
+     {{/compare}}
+    
+     {{#compare value ">=" 10}}
+     The value is greater or equal than 10
+     {{else}}
+     The value is lower than 10
+     {{/compare}}
+

--- a/oocss/documentation/handlebar-helpers-reference.md
+++ b/oocss/documentation/handlebar-helpers-reference.md
@@ -23,3 +23,10 @@ usage:
      The value is lower than 10
      {{/compare}}
 
+#####nl2br (text)
+
+|Param     |Description
+|----------|------------|
+|text      |Text which you want to replace a new line (\n\r) to a &lt;br /&gt;
+
+

--- a/oocss/documentation/handlebar-helpers-reference.md
+++ b/oocss/documentation/handlebar-helpers-reference.md
@@ -119,3 +119,72 @@ Type    |Description
      {{/format}}
 
 ***
+####htmlcode (codeLang, options)
+
+>Adds &lt;pre&gt;&lt;code&gt; tags around code placed inside the {{code}} place holder
+
+|Param       |Type    |Description
+|------------|--------|--------------
+|codeLang    |{String}|[optional] The code language. Default is html.
+|options     |{Object}|[optional] Object passed through handlebars
+
+>**Return:**
+
+Type     |Description
+|--------|-----------
+|{String}|formatted html code placed inside pre and code tags
+
+>**Usage:**
+
+     {{#htmcode}}
+          html here
+     {{/htmlcode}}
+     
+     or with params
+     
+     {{#htmcode "html"}}
+          html here
+     {{/htmlcode}}
+     
+***
+####debug (outputText)
+>debug helper which writes the contents of the *this* object to the console.
+
+|Param       |Type    |Description
+|------------|--------|--------------
+|outputText  |{String}|[optional] Text you want to be logged to the console
+
+>**Return:**
+
+none
+
+>**Usage:**
+
+     {{debug}} 
+     
+     or 
+     
+     {{debug "this is text printed in the console" }}
+
+***
+####partial (name, options)
+>Allows you to create re-usable String templates or compiled template functions.
+>[More info](https://github.com/wycats/handlebars.js/#partials)
+
+|Param    |Type    |Description
+|---------|--------|--------------
+|name     |{String}|Name of the partial
+|options  |{Object}|[optional] Object passed through handlebars
+
+
+>**Return:**
+
+none
+
+>**Declaration:**
+
+     {#partial "myPartialName"}} Home {{/partial}}
+
+>**Usage:**
+     
+     {{> myPartialName}}

--- a/oocss/src/components/form/fieldGroup/fieldGroup.handlebars
+++ b/oocss/src/components/form/fieldGroup/fieldGroup.handlebars
@@ -59,7 +59,7 @@
   {{#ffield}}
     {{#flabel "" "fieldLabel"}}Your email addresses{{/flabel}}
     {{#fgroup}}
-      {{#repeat 2 "inputblock"}}
+      {{#repeat 2 "emailInputblock"}}
         {{#fgroupitem "ftext" @indexStr "" ""}}Email address {{@index}}{{/fgroupitem}}
       {{/repeat}}
     {{/fgroup}}
@@ -72,7 +72,7 @@
   {{#ffield}}
     {{#flabel "" "fieldLabel"}}Select your options{{/flabel}}
     {{#fgroup}}
-      {{#repeat 2 "inputblock"}}
+      {{#repeat 2 "selectInputblock"}}
         {{#fgroupitem "fselect" @indexStr "" "" "" "" "" 2}}Option {{@index}}{{/fgroupitem}}
       {{/repeat}}
     {{/fgroup}}

--- a/oocss/tools/files/handlebars.helpers.js
+++ b/oocss/tools/files/handlebars.helpers.js
@@ -140,7 +140,8 @@ var Handlebars,
             max = max*1; // parseint
             for (var i = start; i <= max; i++) {
                 data.index = i;
-                data.indexStr = indexPrefix;
+                 /* appends index to the indexStr so it's unique */
+                data.indexStr = indexPrefix + i;
                 str.push(options.fn(this, {data: data}));
             }
             return str.join('');


### PR DESCRIPTION
Field Group Label->Id & For attributes where all referencing the same Id so
when you clicked the second+ label in the group it always selected the
first Field Group Item.
