### PR TITLE
Duplicate field group label Ids

### DIFF
--- a/oocss/src/components/form/fieldGroup/fieldGroup.handlebars
+++ b/oocss/src/components/form/fieldGroup/fieldGroup.handlebars
@@ -59,7 +59,7 @@
   {{#ffield}}
     {{#flabel "" "fieldLabel"}}Your email addresses{{/flabel}}
     {{#fgroup}}
-      {{#repeat 2 "inputblock"}}
+      {{#repeat 2 "emailInputblock"}}
         {{#fgroupitem "ftext" @indexStr "" ""}}Email address {{@index}}{{/fgroupitem}}
       {{/repeat}}
     {{/fgroup}}
@@ -72,7 +72,7 @@
   {{#ffield}}
     {{#flabel "" "fieldLabel"}}Select your options{{/flabel}}
     {{#fgroup}}
-      {{#repeat 2 "inputblock"}}
+      {{#repeat 2 "selectInputblock"}}
         {{#fgroupitem "fselect" @indexStr "" "" "" "" "" 2}}Option {{@index}}{{/fgroupitem}}
       {{/repeat}}
     {{/fgroup}}

--- a/oocss/src/components/form/form_doc.handlebars
+++ b/oocss/src/components/form/form_doc.handlebars
@@ -69,8 +69,8 @@
   <p>Add class <code>labelLeft</code> to <code>label</code>.</p>
   {{#formpres "" "" "htmlcode"}}
     {{#ffield}}
-      {{#flabel "text1" "labelLeft fieldLabel"}}Label on the left{{/flabel}}
-      {{#ftext "text1"}}{{/ftext}}
+      {{#flabel "singleLabelText1" "labelLeft fieldLabel"}}Label on the left{{/flabel}}
+      {{#ftext "singleLabelText1"}}{{/ftext}}
     {{/ffield}}
   {{/formpres}}
   <h5>Multiple fields with label on left</h5>

--- a/oocss/tools/files/handlebars.helpers.js
+++ b/oocss/tools/files/handlebars.helpers.js
@@ -140,7 +140,8 @@ var Handlebars,
             max = max*1; // parseint
             for (var i = start; i <= max; i++) {
                 data.index = i;
-                data.indexStr = indexPrefix;
+                 /* appends index to the indexStr so it's unique */
+                data.indexStr = indexPrefix + i;
                 str.push(options.fn(this, {data: data}));
             }
             return str.join('');


### PR DESCRIPTION
Field Group Label->Id & For attributes were all referencing the same Id so
when you clicked the second+ label in the group it always selected the
first Field Group Item.
