### PR TITLE
Fixes "make build" not compiling screen.css\doc.css

### DIFF
--- a/oocss/makefile
+++ b/oocss/makefile
@@ -16,7 +16,7 @@ build: clean
 	@mkdir ${BUILDDIR}
 	@echo "\n${HR}"
 	@mkdir build/css
-#	@cd tools/config; compass compile
+	@cd tools/config; compass compile
 	@echo "Building CSS Files with Sass..."
 	@echo "\n${HR}"
 	@echo "Building Documentation..."


### PR DESCRIPTION
For some unknown reason "compass compile" was commented out and therefore "screen.css and doc.css" doesn't get compiled and copied to the build folder when running "make build".
