### PR TITLE
Fix "make start" error with new VM instance

### DIFF
--- a/oocss/tools/vagrant/vagrant_user.sh
+++ b/oocss/tools/vagrant/vagrant_user.sh
@@ -2,4 +2,4 @@
 
 echo "Auto Provisionning Starting"
 cd /home/vagrant
-cat .profile | grep make\ start && echo "Installed" || echo     "cd /vagrant; make start" >> .profile
+cat .profile | grep make\ init && echo "Installed" || echo     "cd /vagrant; make init" >> .profile


### PR DESCRIPTION
Fixes error when bringing up a new instance of the VM. The "start" command is not in the makefile, but "init" is.
