### PR TITLE
Support <label><input></label> style for checkboxes and radio buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 #OOCSS
-[Look into oocss folder for more information](https://github.com/stubbornella/oocss/tree/master/oocss)
+[Look into oocss folder for more information](https://github.com/mbrowne/oocss/tree/master/oocss)
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 #OOCSS
-[Look into oocss folder for more informations](https://github.com/stubbornella/oocss/tree/master/oocss)
+[Look into oocss folder for more information](https://github.com/stubbornella/oocss/tree/master/oocss)
 

--- a/oocss/README.md
+++ b/oocss/README.md
@@ -107,9 +107,12 @@ These are the essential commands you'll be interested in:
 
 ## <a id="build"></a>Build the project
 
-If you will be doing development on the project, you'll need to know a bit more about the build system. If not, you can happily skip this section. We use Make to create the style guide and the rest of the build directory.
+<!-- commenting because my experience was that the project did not build automatically upon running the mac-start.command and I had to run make bw -->
+<!-- If you will be doing development on the project, you'll need to know a bit more about the build system. If not, you can happily skip this section. -->
+We use Make to create the style guide and the rest of the build directory. When building the project for the first time, run:
+> `make bw`
 
-Some common commands you'll need:
+If you will be making changes to the project, here are some common commands you'll need:
 
 * `make build` - Creates the style guide and all the JavaScript, HTML, and CSS files required for it.
 * `make watch` -  Watches JavaScript, handlebars, and Sass files When any changes are saved, it automatically rebuilds the project so you can see the latest changes.

--- a/oocss/src/components/form/checkboxRadio/_checkboxRadio.scss
+++ b/oocss/src/components/form/checkboxRadio/_checkboxRadio.scss
@@ -14,11 +14,15 @@
     label {
       display: block;
       width: auto;
-      padding-left: 1.4em;
+      padding-left: 0;
       *zoom: 1;
-      *padding-left: 0;
       vertical-align: middle;
     }
+    //for labels and/or other adjacent text that spans more than one line
+    .hangingIndent {
+      padding-left: 1.4em;
+    }
+
     input {
       margin-right: 5px;
       padding: 0;

--- a/oocss/src/components/form/checkboxRadio/checkboxRadio.handlebars
+++ b/oocss/src/components/form/checkboxRadio/checkboxRadio.handlebars
@@ -1,15 +1,6 @@
 {{!include "../form.handlebars"}}
 {{!include "../label/label.handlebars"}}
 
-{{#registerBlock "fradio" "id" "name" "classname"}}
-  <span class="fieldItem radio{{#if $classname}} {{$classname}}{{/if}}">
-    <input type="radio" id="{{$id}}"{{#if $name}} name="{{$name}}"{{/if}}>
-    <label for="{{$id}}">
-      Label for radio button
-    </label>
-</span>
-{{/registerBlock}}
-
 {{#registerBlock "fcheckbox" "id" "name" "classname"}}
   <span class="fieldItem checkbox{{#if $classname}} {{$classname}}{{/if}}">
     <input type="checkbox" id="{{$id}}"{{#if $name}} name="{{$name}}"{{/if}}>
@@ -19,6 +10,35 @@
   </span>
 {{/registerBlock}}
 
+{{#registerBlock "fcheckbox_hangingIndent" "id" "name" "classname"}}
+  <span class="fieldItem checkbox{{#if $classname}} {{$classname}}{{/if}}">
+    <input type="checkbox" id="{{$id}}"{{#if $name}} name="{{$name}}"{{/if}}>
+    <label for="{{$id}}" class="hangingIndent">
+      Label for<br>
+      checkbox
+    </label>
+  </span>
+{{/registerBlock}}
+
+{{#registerBlock "fradio" "id" "name" "classname"}}
+  <span class="fieldItem radio{{#if $classname}} {{$classname}}{{/if}}">
+    <label>
+      <input type="radio" id="{{$id}}"{{#if $name}} name="{{$name}}"{{/if}}>
+      Label for radio button
+    </label>
+</span>
+{{/registerBlock}}
+
+{{#registerBlock "fradio_hangingIndent" "id" "name" "classname"}}
+  <span class="fieldItem radio{{#if $classname}} {{$classname}}{{/if}}">
+    <input type="radio" id="{{$id}}"{{#if $name}} name="{{$name}}"{{/if}}>
+    <label for="{{$id}}" class="hangingIndent">
+      Label for<br>
+      radio button
+    </label>
+</span>
+{{/registerBlock}}
+
 <h3>Checkbox</h3>
 {{#formpres "" "" "htmlcode"}}
   {{#ffield}}
@@ -26,9 +46,29 @@
   {{/ffield}}
 {{/formpres}}
 
+<p>If the label for your checkbox spans multiple lines,
+or if you prefer not to nest your checkbox inside the label,
+use .hangingIndent:</p>
+
+{{#formpres "" "" "htmlcode"}}
+  {{#ffield}}
+    {{#fcheckbox_hangingIndent "checkbox1-1" "checkbox1"}}{{/fcheckbox_hangingIndent}}
+  {{/ffield}}
+{{/formpres}}
+
 <h3>Radio</h3>
 {{#formpres "" "" "htmlcode"}}
   {{#ffield}}
     {{#fradio "radio1-1" "radio1"}}{{/fradio}}
+  {{/ffield}}
+{{/formpres}}
+
+<p>If the label for your radio button spans multiple lines,
+or if you prefer not to nest your checkbox inside the label,
+use .hangingIndent:</p>
+
+{{#formpres "" "" "htmlcode"}}
+  {{#ffield}}
+    {{#fradio_hangingIndent "radio1-1" "radio1"}}{{/fradio_hangingIndent}}
   {{/ffield}}
 {{/formpres}}


### PR DESCRIPTION
As posted on the OOCSS forum: https://groups.google.com/forum/#!topic/object-oriented-css/m5m_SbCLoCc
The issue I had was with checkboxes and radio buttons...as long as my HTML was like the examples, it was fine, but sometimes I like to wrap my <label> tag around the checkbox or radio button, e.g.:

```
<label>
  <input type="checkbox"> Check me
</label>
```

And if I want to use the style shown in the docs, I just need to add the hanging-indent class:

```
<input type="checkbox" id="checkbox1">
<label for="checkbox1" class="hangingIndent"> Check me</label>
```

If anyone has any other ideas I think it would be good to discuss them, but in any case I think both styles of HTML should be supported.

I'm happy to update the documentation file as well if this pull request is accepted. Thank you.
